### PR TITLE
Remove unneeded module.exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ function RawSource(value) {
 	Source.call(this);
 	this._value = value;
 }
-module.exports = RawSource;
 
 RawSource.prototype = Object.create(Source.prototype);
 RawSource.prototype._bake = function() {


### PR DESCRIPTION
It looks like an additional `module.exports` was copied which later get overwritten by `module.exports = CompressionPlugin;`.
