### PR TITLE
feat: remove new redundant options arg from algorithm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# compression plugin for webpack
+
+## Usage
+
+``` javascript
+var CompressionPlugin = require("compression-webpack-plugin");
+module.exports = {
+	plugins: [
+		new CompressionPlugin({
+			asset: "{file}.gz",
+			algorithm: "gzip",
+			regExp: /\.js$|\.html$/,
+			threshold: 10240,
+			minRatio: 0.8
+		})
+	]
+}
+```
+
+Arguments:
+
+* `asset`: The target asset name. `{file}` is replaced with the original asset. Defaults to `"{file}.gz"`.
+* `algorithm`: Can be a `function(buf, callback)` or a string. For a string the algorithm is tacken from `zlib`. Defaults to `"gzip"`.
+* `regExp`: All assets matching this RegExp are processed. Defaults to every asset.
+* `threshold`: Only assets bigger than this size are processed. In bytes. Defaults to `0`.
+* `minRatio`: Only assets that compress better that this ratio are processed. Defaults to `0.8`.
+
+## License
+
+MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module.exports = {
 		new CompressionPlugin({
 			asset: "[path].gz[query]",
 			algorithm: "gzip",
-			test: /\.js$|\.html$/,
+			test: /\.(js|html)$/,
 			threshold: 10240,
 			minRatio: 0.8
 		})

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ var CompressionPlugin = require("compression-webpack-plugin");
 module.exports = {
 	plugins: [
 		new CompressionPlugin({
-			asset: "{file}.gz",
+			asset: "[path].gz[query]",
 			algorithm: "gzip",
-			regExp: /\.js$|\.html$/,
+			test: /\.js$|\.html$/,
 			threshold: 10240,
 			minRatio: 0.8
 		})
@@ -19,9 +19,9 @@ module.exports = {
 
 Arguments:
 
-* `asset`: The target asset name. `{file}` is replaced with the original asset. Defaults to `"{file}.gz"`.
+* `asset`: The target asset name. `[file]` is replaced with the original asset. `[path]` is replaced with the path of the original asset and `[query]` with the query. Defaults to `"[path].gz[query]"`.
 * `algorithm`: Can be a `function(buf, callback)` or a string. For a string the algorithm is taken from `zlib` (or zopfli for `zopfli`). Defaults to `"gzip"`.
-* `regExp`: All assets matching this RegExp are processed. Defaults to every asset.
+* `test`: All assets matching this RegExp are processed. Defaults to every asset.
 * `threshold`: Only assets bigger than this size are processed. In bytes. Defaults to `0`.
 * `minRatio`: Only assets that compress better that this ratio are processed. Defaults to `0.8`.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Arguments:
 * `test`: All assets matching this RegExp are processed. Defaults to every asset.
 * `threshold`: Only assets bigger than this size are processed. In bytes. Defaults to `0`.
 * `minRatio`: Only assets that compress better that this ratio are processed. Defaults to `0.8`.
+* `deleteOriginalAssets`: Whether to delete the original assets or not. Defaults to `false`.
 
 Option Arguments for Zopfli (see [node-zopfli](https://github.com/pierreinglebert/node-zopfli#options) doc for details):
 * verbose: Default: false,

--- a/index.js
+++ b/index.js
@@ -4,19 +4,7 @@
 */
 var async = require("async");
 
-var Source = require("webpack/lib/Source");
-
-function RawSource(value) {
-	Source.call(this);
-	this._value = value;
-}
-
-RawSource.prototype = Object.create(Source.prototype);
-RawSource.prototype._bake = function() {
-	return {
-		source: this._value
-	};
-};
+var RawSource = require("webpack/lib/RawSource");
 
 function CompressionPlugin(options) {
 	options = options || {};

--- a/index.js
+++ b/index.js
@@ -32,7 +32,15 @@ function CompressionPlugin(options) {
 			var zlib = require("zlib");
 			this.algorithm = zlib[this.algorithm];
 			if(!this.algorithm) throw new Error("Algorithm not found in zlib");
-			this.algorithm = this.algorithm.bind(zlib);
+			this.algorithm = this.algorithm.bind(zlib, {
+				level: options.level || 9,
+				flush: options.flush,
+				chunkSize: options.chunkSize,
+				windowBits: options.windowBits,
+				memLevel: options.memLevel,
+				strategy: options.strategy,
+				dictionary: options.dictionary
+			});
 		}
 	}
 	this.regExp = options.regExp;

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function CompressionPlugin(options) {
 module.exports = CompressionPlugin;
 
 CompressionPlugin.prototype.apply = function(compiler) {
-	compiler.plugin("compilation", function(compilation) {
+	compiler.plugin("this-compilation", function(compilation) {
 		compilation.plugin("optimize-assets", function(assets, callback) {
 			async.forEach(Object.keys(assets), function(file, callback) {
 				if(this.regExp && !this.regExp.test(file)) return callback();

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ function CompressionPlugin(options) {
 	this.test = options.test || options.regExp;
 	this.threshold = options.threshold || 0;
 	this.minRatio = options.minRatio || 0.8;
+	this.deleteOriginalAssets = options.deleteOriginalAssets || false;
 }
 module.exports = CompressionPlugin;
 
@@ -80,6 +81,9 @@ CompressionPlugin.prototype.apply = function(compiler) {
 						return sub[p1];
 					});
 					assets[newFile] = new RawSource(result);
+					if (this.deleteOriginalAssets) {
+						delete assets[file];
+					}
 					callback();
 				}.bind(this));
 			}.bind(this), callback);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,59 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var async = require("async");
+
+var Source = require("webpack/lib/Source");
+
+function RawSource(value) {
+	Source.call(this);
+	this._value = value;
+}
+module.exports = RawSource;
+
+RawSource.prototype = Object.create(Source.prototype);
+RawSource.prototype._bake = function() {
+	return {
+		source: this._value
+	};
+};
+
+function CompressionPlugin(options) {
+	options = options || {};
+	this.asset = options.asset || "{file}.gz";
+	this.algorithm = options.algorithm || "gzip";
+	if(typeof this.algorithm === "string") {
+		var zlib = require("zlib");
+		this.algorithm = zlib[this.algorithm];
+		if(!this.algorithm) throw new Error("Algorithm not found in zlib");
+		this.algorithm = this.algorithm.bind(zlib);
+	}
+	this.regExp = options.regExp;
+	this.threshold = options.threshold || 0;
+	this.minRatio = options.minRatio || 0.8;
+}
+module.exports = CompressionPlugin;
+
+CompressionPlugin.prototype.apply = function(compiler) {
+	compiler.plugin("compilation", function(compilation) {
+		compilation.plugin("optimize-assets", function(assets, callback) {
+			async.forEach(Object.keys(assets), function(file, callback) {
+				if(this.regExp && !this.regExp.test(file)) return callback();
+				var asset = assets[file];
+				var content = asset.source();
+				if(!Buffer.isBuffer(content))
+					content = new Buffer(content, "utf-8");
+				var originalSize = content.length;
+				if(originalSize < this.threshold) return callback();
+				this.algorithm(content, function(err, result) {
+					if(err) return callback(err);
+					if(result.length / originalSize > this.minRatio) return callback();
+					var newFile = this.asset.replace(/\{file\}/g, file);
+					assets[newFile] = new RawSource(result);
+					callback();
+				}.bind(this));
+			}.bind(this), callback);
+		}.bind(this));
+	}.bind(this));
+};

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
 	"name": "compression-webpack-plugin",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"author": "Tobias Koppers @sokra",
 	"description": "Prepare compressed versions of assets to serve them with Content-Encoding",
 	"peerDependencies": {
-		"webpack": ">=0.11 <0.12"
+		"webpack": ">=0.11 <2"
 	},
 	"dependencies": {
 		"async": "0.2.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compression-webpack-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Tobias Koppers @sokra",
   "description": "Prepare compressed versions of assets to serve them with Content-Encoding",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "compression-webpack-plugin",
+	"version": "0.1.0",
+	"author": "Tobias Koppers @sokra",
+	"description": "Prepare compressed versions of assets to serve them with Content-Encoding",
+	"peerDependencies": {
+		"webpack": ">=0.11 <0.12"
+	},
+	"dependencies": {
+		"async": "0.2.x"
+	},
+	"homepage": "http://github.com/webpack/compression-webpack-plugin",
+	"repository": {
+		"type": "git",
+		"url": "http://github.com/webpack/compression-webpack-plugin.git"
+	},
+	"licenses": [
+		{
+			"type": "MIT",
+			"url": "http://www.opensource.org/licenses/mit-license.php"
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compression-webpack-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Tobias Koppers @sokra",
   "description": "Prepare compressed versions of assets to serve them with Content-Encoding",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,11 +3,9 @@
   "version": "0.2.0",
   "author": "Tobias Koppers @sokra",
   "description": "Prepare compressed versions of assets to serve them with Content-Encoding",
-  "peerDependencies": {
-    "webpack": ">=0.11 <2"
-  },
   "dependencies": {
-    "async": "0.2.x"
+    "async": "0.2.x",
+    "webpack-sources": "^0.1.0"
   },
   "optionalDependencies": {
     "node-zopfli": "^1.3.4"

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-	"name": "compression-webpack-plugin",
-	"version": "0.1.2",
-	"author": "Tobias Koppers @sokra",
-	"description": "Prepare compressed versions of assets to serve them with Content-Encoding",
-	"peerDependencies": {
-		"webpack": ">=0.11 <2"
-	},
-	"dependencies": {
-		"async": "0.2.x"
-	},
-	"homepage": "http://github.com/webpack/compression-webpack-plugin",
-	"repository": {
-		"type": "git",
-		"url": "http://github.com/webpack/compression-webpack-plugin.git"
-	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	]
+  "name": "compression-webpack-plugin",
+  "version": "0.2.0",
+  "author": "Tobias Koppers @sokra",
+  "description": "Prepare compressed versions of assets to serve them with Content-Encoding",
+  "peerDependencies": {
+    "webpack": ">=0.11 <2"
+  },
+  "dependencies": {
+    "async": "0.2.x"
+  },
+  "homepage": "http://github.com/webpack/compression-webpack-plugin",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/webpack/compression-webpack-plugin.git"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "compression-webpack-plugin",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"author": "Tobias Koppers @sokra",
 	"description": "Prepare compressed versions of assets to serve them with Content-Encoding",
 	"peerDependencies": {


### PR DESCRIPTION
It was introduced in 0.3.1 and broke configurations passing an explicit
algorithm function, as the signature used to be `function(buff, cb)`.

This implements option 1 from #25.
