### PR TITLE
#25 Option 2: Populate options for custom algorithm functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module.exports = {
 Arguments:
 
 * `asset`: The target asset name. `[file]` is replaced with the original asset. `[path]` is replaced with the path of the original asset and `[query]` with the query. Defaults to `"[path].gz[query]"`.
-* `algorithm`: Can be a `function(buf, callback)` or a string. For a string the algorithm is taken from `zlib` (or zopfli for `zopfli`). Defaults to `"gzip"`.
+* `algorithm`: Can be a `function(buf, options, callback)` or a string. For a string the algorithm is taken from `zlib` (or zopfli for `zopfli`). Defaults to `"gzip"`. Options contains any options passed to the constructor which aren't listed here.
 * `test`: All assets matching this RegExp are processed. Defaults to every asset.
 * `threshold`: Only assets bigger than this size are processed. In bytes. Defaults to `0`.
 * `minRatio`: Only assets that compress better that this ratio are processed. Defaults to `0.8`.


### PR DESCRIPTION
Previously the options object passed to custom algorithms was always
an empty object. Now it contains any options passed to the constructor
which aren't general plugin options.

This implements option 2 from #25.
