### PR TITLE
docs(README): improve lead-in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
       src="https://cdn.rawgit.com/webpack/media/e7485eb2/logo/icon.svg">
   </a>
   <h1>Compression Plugin</h1>
-  <p>Compression plugin for Webpack.<p>
+  <p>Prepare compressed versions of assets to serve them with Content-Encoding.<p>
 </div>
 
 <h2 align="center">Install</h2>


### PR DESCRIPTION
This is useful for webpack.js.org where the only lead-in description of this plugin "Compression plugin for webpack" which doesn't say much. See [this page](https://webpack.js.org/plugins/compression-webpack-plugin/) in the docs.