### PR TITLE
refactor: Remove node-zopfli loose dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+
+<a name="0.5.0"></a>
+# [0.4.0](https://github.com/webpack/compression-webpack-plugin/compare/v0.3.2...v0.4.0) (2017-04-08)
+
+
+### Features
+
+* Removed node-zopfli. It complicated the npm install process. There should be another webpack plugin which uses only node-zopfli.
+
 <a name="0.4.0"></a>
 # [0.4.0](https://github.com/webpack/compression-webpack-plugin/compare/v0.3.2...v0.4.0) (2017-04-08)
 

--- a/README.md
+++ b/README.md
@@ -39,19 +39,11 @@ Arguments:
 
 * `asset`: The target asset name. `[file]` is replaced with the original asset. `[path]` is replaced with the path of the original asset and `[query]` with the query. Defaults to `"[path].gz[query]"`.
 * `filename`: A `function(asset)` which receives the asset name (after processing `asset` option) and returns the new asset name. Defaults to `false`.
-* `algorithm`: Can be a `function(buf, callback)` or a string. For a string the algorithm is taken from `zlib` (or zopfli for `zopfli`). Defaults to `"gzip"`.
+* `algorithm`: Can be a `function(buf, callback)` or a string. For a string the algorithm is taken from `zlib`. Defaults to `"gzip"`. `zopfli` was removed because of the optional dependency which needed python.
 * `test`: All assets matching this RegExp are processed. Defaults to every asset.
 * `threshold`: Only assets bigger than this size are processed. In bytes. Defaults to `0`.
 * `minRatio`: Only assets that compress better that this ratio are processed. Defaults to `0.8`.
 * `deleteOriginalAssets`: Whether to delete the original assets or not. Defaults to `false`.
-
-Option Arguments for Zopfli (see [node-zopfli](https://github.com/pierreinglebert/node-zopfli#options) doc for details):
-* verbose: Default: false,
-* verbose_more: Default: false,
-* numiterations: Default: 15,
-* blocksplitting: Default: true,
-* blocksplittinglast: Default: false,
-* blocksplittingmax: Default: 15
 
 <h2 align="center">Maintainers</h2>
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ function CompressionPlugin(options) {
 	this.compressionOptions = {};
 	if(typeof this.algorithm === "string") {
 		if (this.algorithm === "zopfli") {
-			throw new Error("This plugin doesn't support zopfli anymore.");	
+			throw new Error("This plugin doesn't support zopfli anymore.",
+							"This functionality has been separated into a separate npm module available at ",
+							"https://github.com/webpack-contrib/zopfli-webpack-plugin");	
 		} else {
 			var zlib = require("zlib");
 			this.algorithm = zlib[this.algorithm];

--- a/index.js
+++ b/index.js
@@ -15,22 +15,7 @@ function CompressionPlugin(options) {
 	this.compressionOptions = {};
 	if(typeof this.algorithm === "string") {
 		if (this.algorithm === "zopfli") {
-			try {
-				var zopfli = require("node-zopfli");
-			} catch(err) {
-				throw new Error("node-zopfli not found");
-			}
-			this.compressionOptions = {
-				verbose: options.hasOwnProperty('verbose') ? options.verbose : false,
-				verbose_more: options.hasOwnProperty('verbose_more') ? options.verbose_more : false,
-				numiterations: options.numiterations ? options.numiterations : 15,
-				blocksplitting: options.hasOwnProperty('blocksplitting') ? options.blocksplitting : true,
-				blocksplittinglast: options.hasOwnProperty('blocksplittinglast') ? options.blocksplittinglast : false,
-				blocksplittingmax: options.blocksplittingmax ? options.blocksplittingmax : 15
-			};
-			this.algorithm = function (content, options, fn) {
-				zopfli.gzip(content, options, fn);
-			};
+			throw new Error("This plugin doesn't support zopfli anymore.");	
 		} else {
 			var zlib = require("zlib");
 			this.algorithm = zlib[this.algorithm];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compression-webpack-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Tobias Koppers @sokra",
   "description": "Prepare compressed versions of assets to serve them with Content-Encoding",
   "scripts": {
@@ -12,9 +12,6 @@
   },
   "devDependencies": {
     "standard-version": "^4.0.0"
-  },
-  "optionalDependencies": {
-    "node-zopfli": "^2.0.0"
   },
   "homepage": "http://github.com/webpack/compression-webpack-plugin",
   "repository": {


### PR DESCRIPTION
As discussed in https://github.com/webpack-contrib/compression-webpack-plugin/issues/56, I've removed the node-zopfli dependency.