### PR TITLE
refactor: Drops optional Zopfli dependency

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,41 +14,22 @@ class CompressionPlugin {
     this.compressionOptions = {};
 
     if (typeof this.algorithm === 'string') {
-      if (this.algorithm === 'zopfli') {
-        try {
-          const zopfli = require('node-zopfli'); // eslint-disable-line no-unused-vars
-        } catch (err) {
-          throw new Error('node-zopfli not found');
-        }
-        this.compressionOptions = {
-          verbose: hasOwnProperty.call(options, 'verbose') ? options.verbose : false,
-          verbose_more: hasOwnProperty.call(options, 'verbose_more') ? options.verbose_more : false,
-          numiterations: options.numiterations ? options.numiterations : 15,
-          blocksplitting: hasOwnProperty.call(options, 'blocksplitting') ? options.blocksplitting : true,
-          blocksplittinglast: hasOwnProperty.call(options, 'blocksplittinglast') ? options.blocksplittinglast : false,
-          blocksplittingmax: options.blocksplittingmax ? options.blocksplittingmax : 15,
-        };
-        this.algorithm = (content, options, fn) => {
-          zopfli.gzip(content, options, fn);
-        };
-      } else {
-        const zlib = require('zlib');
-        this.algorithm = zlib[this.algorithm];
+      const zlib = require('zlib');
+      this.algorithm = zlib[this.algorithm];
 
-        if (!this.algorithm) {
-          throw new Error('Algorithm not found in zlib');
-        }
-
-        this.compressionOptions = {
-          level: options.level || 9,
-          flush: options.flush,
-          chunkSize: options.chunkSize,
-          windowBits: options.windowBits,
-          memLevel: options.memLevel,
-          strategy: options.strategy,
-          dictionary: options.dictionary,
-        };
+      if (!this.algorithm) {
+        throw new Error('Algorithm not found in zlib');
       }
+
+      this.compressionOptions = {
+        level: options.level || 9,
+        flush: options.flush,
+        chunkSize: options.chunkSize,
+        windowBits: options.windowBits,
+        memLevel: options.memLevel,
+        strategy: options.strategy,
+        dictionary: options.dictionary,
+      };
     }
     this.test = options.test || options.regExp;
     this.threshold = options.threshold || 0;


### PR DESCRIPTION
 - Zopfli has been broken out to it's own repo.

Squash merge commit message body ...
```
BREAKING CHANGE: The optional dependency for Zopfli was causing issues in consumers CI / CD chains, this option has now been removed.

MIGRATION: Zopfli is now in it's own plugin the options have remained the same. For those using the Zopfli option in `compression-webpack-plugin` swap it out for `https://github.com/webpack-contrib/zopfli-webpack-plugin`
```
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
