### PR TITLE
Fix URI for PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
+1. [Read and sign the CLA](https://cla.js.foundation/webpack-contrib/compression-webpack-plugin). This needs to be done only once. PRs that haven't signed it won't be accepted.
 2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
 3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
 -->


### PR DESCRIPTION
`https://cla.js.foundation/webpack/webpack.js.org` -> `https://cla.js.foundation/webpack-contrib/compression-webpack-plugin`

other repo?