### PR TITLE
docs(README): remove `zopfli`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,11 @@ Arguments:
 
 * `asset`: The target asset name. `[file]` is replaced with the original asset. `[path]` is replaced with the path of the original asset and `[query]` with the query. Defaults to `"[path].gz[query]"`.
 * `filename`: A `function(asset)` which receives the asset name (after processing `asset` option) and returns the new asset name. Defaults to `false`.
-* `algorithm`: Can be a `function(buf, callback)` or a string. For a string the algorithm is taken from `zlib` (or zopfli for `zopfli`). Defaults to `"gzip"`.
+* `algorithm`: Can be a `function(buf, callback)` or a string. For a string the algorithm is taken from `zlib`. Defaults to `"gzip"`.
 * `test`: All assets matching this RegExp are processed. Defaults to every asset.
 * `threshold`: Only assets bigger than this size are processed. In bytes. Defaults to `0`.
 * `minRatio`: Only assets that compress better that this ratio are processed. Defaults to `0.8`.
 * `deleteOriginalAssets`: Whether to delete the original assets or not. Defaults to `false`.
-
-Option Arguments for Zopfli (see [node-zopfli](https://github.com/pierreinglebert/node-zopfli#options) doc for details):
-* verbose: Default: false,
-* verbose_more: Default: false,
-* numiterations: Default: 15,
-* blocksplitting: Default: true,
-* blocksplittinglast: Default: false,
-* blocksplittingmax: Default: 15
 
 <h2 align="center">Maintainers</h2>
 


### PR DESCRIPTION
Since there's no way to use this plugin with zopfli since v1, it's probably nice to remove it from readme as well

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
