### PR TITLE
docs(README): fix typo in `options` table (`options.minRatio`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module.exports = {
 |**`filename`**|`{Function}`|`false`|A `{Function}` `(asset) => asset` which receives the asset name (after processing `asset` option) and returns the new asset name|
 |**`algorithm`**|`{String\|Function}`|`gzip`|Can be `(buffer, cb) => cb(buffer)` or if a `{String}` is used the algorithm is taken from `zlib`|
 |**`threshold`**|`{Number}`|`0`|Only assets bigger than this size are processed. In bytes.|
-|**`minRatio`**|`{Number}`|`0.8`|Only assets that compress better that this ratio are processed|
+|**`minRatio`**|`{Number}`|`0.8`|Only assets that compress better than this ratio are processed|
 |**`deleteOriginalAssets`**|`{Boolean}`|`false`|Whether to delete the original assets or not|
 
 ### `test`


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
