### PR TITLE
fix(index): don't use `JSON.stringify()` to serialize the  `cache` data (`options.cache`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,12 +101,12 @@ class CompressionPlugin {
               return cacache
                 .get(cacheDir, cacheKey)
                 .then(
-                  result => JSON.parse(result.data),
+                  result => result.data,
                   () => Promise
                     .resolve()
                     .then(() => this.compress(content))
                     .then(
-                      data => cacache.put(cacheDir, cacheKey, JSON.stringify(data))
+                      data => cacache.put(cacheDir, cacheKey, data.toString())
                         .then(() => data),
                     ),
                 );


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

We should avoid using `JSON.stringify` because `data` is buffer and after get from cache we return `{type: 'Buffer', data: [...]}` and this object don't have `length` (because it is now not `Buffer` it is just plain object with properties) - `minRation` doesn't work.

Other cached package also can contain error. I investigate this right now.