### PR TITLE
chore(package): relax semver range of `async` dependency (`dependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "webpack-defaults": "webpack-defaults"
   },
   "dependencies": {
-    "async": "2.4.1",
+    "async": "^2.4.1",
     "cacache": "^10.0.1",
     "find-cache-dir": "^1.0.0",
     "serialize-javascript": "^1.4.0",


### PR DESCRIPTION
Fixing `async`'s version does not seem to be required.