### PR TITLE
fix: `cache` behavior

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ class CompressionPlugin {
                     .resolve()
                     .then(() => this.compress(content))
                     .then(
-                      data => cacache.put(cacheDir, cacheKey, data.toString())
+                      data => cacache.put(cacheDir, cacheKey, data)
                         .then(() => data),
                     ),
                 );


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Why? Because `.toString()` convert binary data to utf8 and it is broke gzip files