### PR TITLE
fix(index): add missing `include` && `exclude` options (`this.options`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ class CompressionPlugin {
     const {
       asset = '[path].gz[query]',
       test,
-      regExp,
+      include,
+      exclude,
       algorithm = 'gzip',
       filename = false,
       compressionOptions = {},
@@ -29,7 +30,8 @@ class CompressionPlugin {
     this.options = {
       asset,
       test,
-      regExp,
+      include,
+      exclude,
       algorithm,
       filename,
       compressionOptions,


### PR DESCRIPTION
### `Issues` 

- Fixes #94

### `Notable Changes`

I also ran into the above issue and confirmed that ModuleFilenameHelpers.matchObject does not get an options object with either include or exclude. They were not getting passed to the internal options object. I removed the regExp option because I'm assuming that it was mistakenly added, as there's no reference to one in the project documentation and it's the typename for the test/include/exclude options.

### `Reproduction`

https://github.com/Stavrus/wpctest
