### PR TITLE
fix(index): `tapable` deprecation warnings (`webpack >= v4.0.0`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class CompressionPlugin {
   }
 
   apply(compiler) {
-    compiler.plugin('emit', (compilation, callback) => {
+    const emit = (compilation, callback) => {
       const { cache, threshold, minRatio, asset: assetName, filename, deleteOriginalAssets } = this.options;
       const cacheDir = cache === true ? findCacheDir({ name: 'compression-webpack-plugin' }) : cache;
 
@@ -143,7 +143,14 @@ class CompressionPlugin {
           })
           .catch(cb);
       }, callback);
-    });
+    };
+
+    if (compiler.hooks) {
+      const plugin = { name: 'CompressionPlugin' };
+      compiler.hooks.emit.tapAsync(plugin, emit);
+    } else {
+      compiler.plugin('emit', emit);
+    }
   }
 
   compress(input) {


### PR DESCRIPTION
Right now the plugin shows this warning when I try to run it with webpack 4.0.0-beta2:

```
DepreciationWarning: Tappable.plugin is deprecated. Use new API on `.hooks` instead
```

This fix will support both webpack 3 and webpack 4 APIs without any warning. This way to deal with the API is recommended by @sokra https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/154#issuecomment-367444806

I need this PR to add `.mjs` support to [Size Limit](https://github.com/ai/size-limit) https://github.com/ai/size-limit/pull/42

@michael-ciniawsky same as https://github.com/webpack-contrib/uglifyjs-webpack-plugin/pull/238