### PR TITLE
docs(readme): update with import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Then add the plugin to your `webpack` config. For example:
 **webpack.config.js**
 
 ```js
+const CompressionPlugin = require('compression-webpack-plugin');
+
 module.exports = {
   plugins: [
     new CompressionPlugin()


### PR DESCRIPTION
Update the "getting started" section with an example importing the Compression Plugin (which is used just below).  This import (require) statement is currently not found in the README.

Not a huge deal, but could save somebody ~5 seconds of having to add that in themselves.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->