### PR TITLE
Force compression when minRatio = 1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ class CompressionPlugin {
                 return this.compress(input);
               })
               .then((result) => {
-                if (result.length / originalSize > minRatio) {
+                if ((result.length / originalSize > minRatio) || minRatio == 1) {
                   return cb();
                 }
 


### PR DESCRIPTION
Currently documentation says if you set minRatio to 1, everything will be compressed.  This actually isn't true.  It still won't compress files that are LARGER than the original.  This update does what the documentation says (rather than saying set minRatio to 99 or something)

This PR contains a:

- [x ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This change makes minRatio 1 actually compress all files.
