### PR TITLE
feat: remove cjs wrapper and generate types in commonjs format

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "type": "opencollective",
     "url": "https://opencollective.com/webpack"
   },
-  "main": "dist/cjs.js",
-  "types": "types/cjs.d.ts",
+  "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">= 12.13.0"
   },
   "scripts": {
     "start": "npm run build -- -w",
-    "clean": "del-cli dist",
+    "clean": "del-cli dist types",
     "prebuild": "npm run clean",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.ts\" --write && prettier types --write",
     "build:code": "cross-env NODE_ENV=production babel src -d dist --copy-files",

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,1 +1,0 @@
-module.exports = require("./index").default;

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,13 @@
   Author Tobias Koppers @sokra
 */
 
-import path from "path";
-import crypto from "crypto";
+const path = require("path");
+const crypto = require("crypto");
 
-import { validate } from "schema-utils";
-import serialize from "serialize-javascript";
+const { validate } = require("schema-utils");
+const serialize = require("serialize-javascript");
 
-import schema from "./options.json";
+const schema = require("./options.json");
 
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
@@ -432,4 +432,4 @@ class CompressionPlugin {
   }
 }
 
-export default CompressionPlugin;
+module.exports = CompressionPlugin;

--- a/test/cjs.test.js
+++ b/test/cjs.test.js
@@ -1,8 +1,0 @@
-import src from "../src";
-import cjs from "../src/cjs";
-
-describe("cjs", () => {
-  it("should exported", () => {
-    expect(cjs).toEqual(src);
-  });
-});

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -1,2 +1,0 @@
-declare const _exports: typeof import("./index").default;
-export = _exports;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,81 +1,5 @@
 /// <reference types="node" />
-export default CompressionPlugin;
-export type Schema = import("schema-utils/declarations/validate").Schema;
-export type Compiler = import("webpack").Compiler;
-export type WebpackPluginInstance = import("webpack").WebpackPluginInstance;
-export type Compilation = import("webpack").Compilation;
-export type Source = import("webpack").sources.Source;
-export type Asset = import("webpack").Asset;
-export type WebpackError = import("webpack").WebpackError;
-export type WithImplicitCoercion<T> =
-  | T
-  | {
-      valueOf(): T;
-    };
-export type Rule = RegExp | string;
-export type Rules = Rule[] | Rule;
-export type CustomOptions = {
-  [key: string]: any;
-};
-export type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
-export type CompressionOptions<T> = InferDefaultType<T>;
-export type AlgorithmFunction<T> = (
-  input: Buffer,
-  options: CompressionOptions<T>,
-  callback: (
-    error: Error | null | undefined,
-    result:
-      | string
-      | ArrayBuffer
-      | SharedArrayBuffer
-      | Uint8Array
-      | readonly number[]
-      | {
-          valueOf(): ArrayBuffer | SharedArrayBuffer;
-        }
-      | {
-          valueOf(): string | Uint8Array | readonly number[];
-        }
-      | {
-          valueOf(): string;
-        }
-      | {
-          [Symbol.toPrimitive](hint: "string"): string;
-        }
-  ) => void
-) => any;
-export type PathData = {
-  [key: string]: any;
-};
-export type Filename = string | ((fileData: PathData) => string);
-export type DeleteOriginalAssets = boolean | "keep-source-map";
-export type BasePluginOptions<T> = {
-  test?: Rules | undefined;
-  include?: Rules | undefined;
-  exclude?: Rules | undefined;
-  threshold?: number | undefined;
-  minRatio?: number | undefined;
-  deleteOriginalAssets?: DeleteOriginalAssets | undefined;
-  filename?: Filename | undefined;
-};
-export type ZlibOptions = import("zlib").ZlibOptions;
-export type DefinedDefaultAlgorithmAndOptions<T> = T extends ZlibOptions
-  ? {
-      algorithm?: string | AlgorithmFunction<T> | undefined;
-      compressionOptions?: CompressionOptions<T> | undefined;
-    }
-  : {
-      algorithm: string | AlgorithmFunction<T>;
-      compressionOptions?: CompressionOptions<T> | undefined;
-    };
-export type InternalPluginOptions<T> = BasePluginOptions<T> & {
-  algorithm: string | AlgorithmFunction<T>;
-  compressionOptions: CompressionOptions<T>;
-  threshold: number;
-  minRatio: number;
-  deleteOriginalAssets: DeleteOriginalAssets;
-  filename: Filename;
-};
+export = CompressionPlugin;
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
 /** @typedef {import("webpack").WebpackPluginInstance} WebpackPluginInstance */
@@ -183,3 +107,104 @@ declare class CompressionPlugin<T = import("zlib").ZlibOptions>
    */
   apply(compiler: Compiler): void;
 }
+declare namespace CompressionPlugin {
+  export {
+    Schema,
+    Compiler,
+    WebpackPluginInstance,
+    Compilation,
+    Source,
+    Asset,
+    WebpackError,
+    WithImplicitCoercion,
+    Rule,
+    Rules,
+    CustomOptions,
+    InferDefaultType,
+    CompressionOptions,
+    AlgorithmFunction,
+    PathData,
+    Filename,
+    DeleteOriginalAssets,
+    BasePluginOptions,
+    ZlibOptions,
+    DefinedDefaultAlgorithmAndOptions,
+    InternalPluginOptions,
+  };
+}
+type WebpackPluginInstance = import("webpack").WebpackPluginInstance;
+type Compiler = import("webpack").Compiler;
+type BasePluginOptions<T> = {
+  test?: Rules | undefined;
+  include?: Rules | undefined;
+  exclude?: Rules | undefined;
+  threshold?: number | undefined;
+  minRatio?: number | undefined;
+  deleteOriginalAssets?: DeleteOriginalAssets | undefined;
+  filename?: Filename | undefined;
+};
+type DefinedDefaultAlgorithmAndOptions<T> = T extends ZlibOptions
+  ? {
+      algorithm?: string | AlgorithmFunction<T> | undefined;
+      compressionOptions?: CompressionOptions<T> | undefined;
+    }
+  : {
+      algorithm: string | AlgorithmFunction<T>;
+      compressionOptions?: CompressionOptions<T> | undefined;
+    };
+type Schema = import("schema-utils/declarations/validate").Schema;
+type Compilation = import("webpack").Compilation;
+type Source = import("webpack").sources.Source;
+type Asset = import("webpack").Asset;
+type WebpackError = import("webpack").WebpackError;
+type WithImplicitCoercion<T> =
+  | T
+  | {
+      valueOf(): T;
+    };
+type Rule = RegExp | string;
+type Rules = Rule[] | Rule;
+type CustomOptions = {
+  [key: string]: any;
+};
+type InferDefaultType<T> = T extends infer U ? U : CustomOptions;
+type CompressionOptions<T> = InferDefaultType<T>;
+type AlgorithmFunction<T> = (
+  input: Buffer,
+  options: CompressionOptions<T>,
+  callback: (
+    error: Error | null | undefined,
+    result:
+      | string
+      | ArrayBuffer
+      | SharedArrayBuffer
+      | Uint8Array
+      | readonly number[]
+      | {
+          valueOf(): ArrayBuffer | SharedArrayBuffer;
+        }
+      | {
+          valueOf(): string | Uint8Array | readonly number[];
+        }
+      | {
+          valueOf(): string;
+        }
+      | {
+          [Symbol.toPrimitive](hint: "string"): string;
+        }
+  ) => void
+) => any;
+type PathData = {
+  [key: string]: any;
+};
+type Filename = string | ((fileData: PathData) => string);
+type DeleteOriginalAssets = boolean | "keep-source-map";
+type ZlibOptions = import("zlib").ZlibOptions;
+type InternalPluginOptions<T> = BasePluginOptions<T> & {
+  algorithm: string | AlgorithmFunction<T>;
+  compressionOptions: CompressionOptions<T>;
+  threshold: number;
+  minRatio: number;
+  deleteOriginalAssets: DeleteOriginalAssets;
+  filename: Filename;
+};


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

fixes #273, improve DX for types

### Breaking Changes

Potentially yes, but we use babel and our code in commonjs format, so we should generate types in the same format

### Additional Info

Now you can use:
```
import {Rule} from 'compression-webpack-plugin'
```