### PR TITLE
fix: compatibility with Node.js@18

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
   Author Tobias Koppers @sokra
 */
 
-import crypto from "crypto";
 import path from "path";
 
 import webpack, {
@@ -14,6 +13,20 @@ import { validate } from "schema-utils";
 import serialize from "serialize-javascript";
 
 import schema from "./options.json";
+
+const internalCreateHash = (algorithm) => {
+  try {
+    // eslint-disable-next-line global-require import/no-unresolved
+    const createHash = require("webpack/lib/util/createHash");
+
+    return createHash(algorithm);
+  } catch (err) {
+    // Ignore
+  }
+
+  return require("crypto").createHash(algorithm);
+};
+
 
 const { RawSource } =
   // eslint-disable-next-line global-require
@@ -229,7 +242,7 @@ class CompressionPlugin {
               originalAlgorithm: this.options.algorithm,
               compressionOptions: this.options.compressionOptions,
               name,
-              contentHash: crypto.createHash("md4").update(input).digest("hex"),
+              contentHash: internalCreateHash("md4").update(input).digest("hex"),
             };
           } else {
             cacheData.name = serialize({


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes https://github.com/webpack-contrib/compression-webpack-plugin/issues/364

### Breaking Changes

No

### Additional Info

Compatibility for Node.js@18 and allow to reuse `require("crypto").createHash` if webpack is lower then https://github.com/webpack/webpack/pull/17628